### PR TITLE
Fix fallout from namespacing.

### DIFF
--- a/lib/manageiq/network_discovery/discover_probe.rb
+++ b/lib/manageiq/network_discovery/discover_probe.rb
@@ -8,7 +8,7 @@ module ManageIQ
           next unless File.fnmatch('?*Probe.rb', pmf)
           pmod = pmf.chomp(".rb")
           require_relative "modules/#{pmod}"
-          Object.const_get(pmod).probe(dobj)
+          ManageIQ::NetworkDiscovery.const_get(pmod).probe(dobj)
         end
         (nil)
       end

--- a/spec/manageiq/network_discovery/discover_probe_spec.rb
+++ b/spec/manageiq/network_discovery/discover_probe_spec.rb
@@ -1,0 +1,21 @@
+require 'ostruct'
+require 'util/miq-ipmi'
+
+describe ManageIQ::NetworkDiscovery::DiscoverProbe do
+  context ".getProductMod" do
+    let(:ost) { OpenStruct.new(:discover_types => [:ipmi], :ipaddr => "127.0.0.1", :hypervisor => []) }
+    it "hypervisor is ipmi when available" do
+      allow(MiqIPMI).to receive(:is_available?).and_return(true)
+      described_class.getProductMod(ost)
+
+      expect(ost.hypervisor).to eql([:ipmi])
+    end
+
+    it "no hypervisor if ipmi isn't available" do
+      allow(MiqIPMI).to receive(:is_available?).and_return(false)
+      described_class.getProductMod(ost)
+
+      expect(ost.hypervisor).to eql([])
+    end
+  end
+end


### PR DESCRIPTION
It appears the namespacing in 7e7fe96209c133e290a7fd44310dc7fdffdc6d70
is the cause of this problem.

When we're in the `ManageIQ::NetworkDiscovery::DiscoverProbe` module namespace,
we cannot do `Object.const_get("IpmiProbe")` and have it find
`ManageIQ::NetworkDiscovery::IpmiProbe`.  Instead, we need to look in the
`ManageIQ::NetworkDiscovery` namespace for `IpmiProbe`.

This worked previously, because IpmiProbe was at the toplevel namespace.